### PR TITLE
Better version management for data stored in server

### DIFF
--- a/notes
+++ b/notes
@@ -5,3 +5,6 @@ Remote Dev
 https://github.com/facebook/nuclide/issues/130
 
 http://clang.llvm.org/docs/ClangFormat.html
+
+GCC 6 installation
+https://gist.github.com/application2000/73fd6f4bf1be6600a2cf9f56315a2d91

--- a/ps-thin/src/petuum_ps/server/server.cpp
+++ b/ps-thin/src/petuum_ps/server/server.cpp
@@ -236,5 +236,4 @@ int32_t Server::GetBgVersion(int32_t bg_thread_id) {
 
 double Server::GetElapsedTime() { return from_start_timer_.elapsed(); }
 
-int32_t Server::GetAsyncModelVersion() { return async_version_; }
 }

--- a/ps-thin/src/petuum_ps/server/server.cpp
+++ b/ps-thin/src/petuum_ps/server/server.cpp
@@ -69,7 +69,7 @@ bool Server::ClockUntil(int32_t bg_id, int32_t clock) {
         new_clock % GlobalContext::get_snapshot_clock() != 0) {
       return true;
     }
-      TakeSnapShot(new_clock);
+    TakeSnapShot(new_clock);
     return true;
   }
   return false;
@@ -207,12 +207,13 @@ ServerTable *Server::GetServerTable(int32_t table_id) {
   return &(table_iter->second);
 }
 
-    void Server::TakeSnapShot(int32_t current_clock) {
+void Server::TakeSnapShot(int32_t current_clock) {
 
-      for (auto table_iter = tables_.begin(); table_iter != tables_.end();
-           table_iter++) {
-        table_iter->second.TakeSnapShot(GlobalContext::get_snapshot_dir(),
-                                        server_id_, table_iter->first, current_clock);
-      }
-    }
+  for (auto table_iter = tables_.begin(); table_iter != tables_.end();
+       table_iter++) {
+    table_iter->second.TakeSnapShot(GlobalContext::get_snapshot_dir(),
+                                    server_id_, table_iter->first,
+                                    current_clock);
+  }
+}
 }

--- a/ps-thin/src/petuum_ps/server/server.cpp
+++ b/ps-thin/src/petuum_ps/server/server.cpp
@@ -181,13 +181,12 @@ void Server::ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
     // TODO (raajay) use delayed based scaling.
     // 1. We have to decide if the scaling has to be determined per-row or on a
     // table basis.
-    // double scaling_factor = GetUpdateScalingFactor(update_model_version);
-    double scaling_factor = 1.0;
 
     // Apply or Create and apply the row op log. This will basically increment
     // the values at the server.
     server_table->FindCreateRow(row_id);
-    bool success = server_table->ApplyRowOpLog(row_id, column_ids, updates, num_updates, scaling_factor);
+    bool success = server_table->ApplyRowOpLog(row_id, column_ids, updates,
+                                               num_updates, 1.0);
     CHECK_EQ(success, true) << "Row not found. row_id=" << row_id;
 
     // get the next row update
@@ -208,8 +207,7 @@ void Server::ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
   }
 
   VLOG(2) << "SERVER: sender_id=" << bg_thread_id
-          << ", server_id=" << server_id_
-          << ", time=" << GetElapsedTime()
+          << ", server_id=" << server_id_ << ", time=" << GetElapsedTime()
           << ", size=" << oplog_size;
 }
 
@@ -220,5 +218,4 @@ int32_t Server::GetBgVersion(int32_t bg_thread_id) {
 }
 
 double Server::GetElapsedTime() { return from_start_timer_.elapsed(); }
-
 }

--- a/ps-thin/src/petuum_ps/server/server.cpp
+++ b/ps-thin/src/petuum_ps/server/server.cpp
@@ -24,23 +24,15 @@ void Server::Init(int32_t server_id, const std::vector<int32_t> &bg_ids,
     bg_version_map_[*iter] = -1;  // the version -1 initially
   }
 
-  // we start with async version -1, it will be incremented to 0, when we init
-  // the parameters.
-  async_version_ = -1;
-
-  push_row_msg_data_size_ = kPushRowMsgSizeInit;
   server_id_ = server_id;
   accum_oplog_count_ = 0;
   is_replica_ = is_replica;
   from_start_timer_.restart();
-
-} // end function - Init
+}
 
 void Server::CreateTable(int32_t table_id, TableInfo &table_info) {
-
   // Each Server object is responsible of different parts of all tables. Thus,
   // a copy of all tables is maintained.
-
   auto ret = tables_.emplace(table_id, ServerTable(table_info));
   CHECK(ret.second);
 
@@ -51,28 +43,24 @@ void Server::CreateTable(int32_t table_id, TableInfo &table_info) {
                                     table_id,
                                     GlobalContext::get_resume_clock());
   }
+}
 
-} // end function -- Create table
-
-// Find a row indexed by table and row id. If no row exists, create a new row
-// and return.
+/**
+ * Find a row indexed by table and row id. If no row exists, create a new row
+ * and return.
+ */
 ServerRow *Server::FindCreateRow(int32_t table_id, int32_t row_id) {
   // access ServerTable via reference to avoid copying
   auto iter = tables_.find(table_id);
   CHECK(iter != tables_.end());
-  ServerTable &server_table = iter->second;
-  ServerRow *server_row = server_table.FindRow(row_id);
-  if (server_row != 0) {
-    return server_row;
-  }
-  server_row = server_table.CreateRow(row_id);
-  return server_row;
-} // end function -- Find create row
+  return iter->second.FindCreateRow(row_id);
+}
 
-// Push the vector clock for a particular bg_id to the specified value. On
-// pushing the clock of a single bg_thread, if the min_value of th vector
-// clock changes, then return true. Also, see if we have to take a snapshot.
-
+/**
+ * Push the vector clock for a particular bg_id to the specified value. On
+ * pushing the clock of a single bg_thread, if the min_value of th vector
+ * clock changes, then return true. Also, see if we have to take a snapshot.
+ */
 bool Server::ClockUntil(int32_t bg_id, int32_t clock) {
   int new_clock = bg_clock_.TickUntil(bg_id, clock);
   if (new_clock) {
@@ -93,7 +81,7 @@ bool Server::ClockUntil(int32_t bg_id, int32_t clock) {
   }
 
   return false;
-} // end function - clock until
+}
 
 // Update an internal data structure to cache all row requests. One row
 // requests are cached, they are replied to only when the clock moves on an
@@ -189,20 +177,20 @@ void Server::ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
 
   while (updates != 0) {
     ++accum_oplog_count_;
-    updateOplogDelay(observed_delay, update_model_version);
-    double scaling_factor = GetUpdateScalingFactor(update_model_version);
 
-    // Apply or Create and apply the row op log. This will basically
-    // increment the values at the server.
-    bool found = server_table->ApplyRowOpLog(row_id, column_ids, updates,
-                                             num_updates, scaling_factor);
+    // TODO (raajay) use delayed based scaling.
+    // 1. We have to decide if the scaling has to be determined per-row or on a
+    // table basis.
+    // double scaling_factor = GetUpdateScalingFactor(update_model_version);
+    double scaling_factor = 1.0;
 
-    if (!found) {
-      server_table->CreateRow(row_id);
-      server_table->ApplyRowOpLog(row_id, column_ids, updates, num_updates,
-                                  scaling_factor);
-    }
-    // get the next row id worth of update
+    // Apply or Create and apply the row op log. This will basically increment
+    // the values at the server.
+    server_table->FindCreateRow(row_id);
+    bool success = server_table->ApplyRowOpLog(row_id, column_ids, updates, num_updates, scaling_factor);
+    CHECK_EQ(success, true) << "Row not found. row_id=" << row_id;
+
+    // get the next row update
     updates = oplog_reader.Next(&table_id, &row_id, &update_model_version,
                                 &column_ids, &num_updates, &started_new_table);
 
@@ -219,13 +207,10 @@ void Server::ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
     }
   }
 
-  VLOG(2) << "Observed delay, sender_id=" << bg_thread_id
+  VLOG(2) << "SERVER: sender_id=" << bg_thread_id
           << ", server_id=" << server_id_
-          << ", server_version=" << async_version_
-          << ", delay=" << *observed_delay << ", time=" << GetElapsedTime()
+          << ", time=" << GetElapsedTime()
           << ", size=" << oplog_size;
-
-  async_version_++; // finally, increment the global version of the model
 }
 
 int32_t Server::GetMinClock() { return bg_clock_.get_min_clock(); }

--- a/ps-thin/src/petuum_ps/server/server.cpp
+++ b/ps-thin/src/petuum_ps/server/server.cpp
@@ -147,15 +147,15 @@ void Server::ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
 
   int32_t table_id;
   int32_t row_id;
-  int32_t update_model_version;
+  int32_t model_version_for_update;
   const int32_t *column_ids; // the variable pointer points to const memory
   int32_t num_updates;
   bool started_new_table;
 
   // read the first few bytes of the message. It will populate the arguments.
   const void *updates =
-      oplog_reader.Next(&table_id, &row_id, &update_model_version, &column_ids,
-                        &num_updates, &started_new_table);
+      oplog_reader.Next(&table_id, &row_id, &model_version_for_update,
+                        &column_ids, &num_updates, &started_new_table);
   CHECK_EQ(started_new_table, false);
 
   ServerTable *server_table;
@@ -177,7 +177,7 @@ void Server::ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
                             << GetTableRowStringId(table_id, row_id);
 
     // get the next row update
-    updates = oplog_reader.Next(&table_id, &row_id, &update_model_version,
+    updates = oplog_reader.Next(&table_id, &row_id, &model_version_for_update,
                                 &column_ids, &num_updates, &started_new_table);
 
     if (updates == 0) {

--- a/ps-thin/src/petuum_ps/server/server.hpp
+++ b/ps-thin/src/petuum_ps/server/server.hpp
@@ -56,7 +56,6 @@ public:
   // Accessors
   int32_t GetMinClock();
   int32_t GetBgVersion(int32_t bg_thread_id);
-  int32_t GetAsyncModelVersion();
   double GetElapsedTime();
 
 private:
@@ -75,8 +74,7 @@ private:
   }
 
   VectorClock bg_clock_;
-  int32_t
-      async_version_; // (raajay) we add this to maintain async version number
+  int32_t async_version_;
   boost::unordered_map<int32_t, ServerTable> tables_;
   // mapping <clock, table id> to an array of row requests
   std::map<int32_t,

--- a/ps-thin/src/petuum_ps/server/server.hpp
+++ b/ps-thin/src/petuum_ps/server/server.hpp
@@ -46,6 +46,12 @@ private:
   HighResolutionTimer from_start_timer_;
   bool is_replica_;
 
+  ServerTable *GetServerTable(int32_t table_id) {
+    auto table_iter = tables_.find(table_id);
+    CHECK(table_iter != tables_.end()) << "Not found table_id = " << table_id;
+    return &(table_iter->second);
+  }
+
 public:
   Server();
   ~Server();

--- a/ps-thin/src/petuum_ps/server/server.hpp
+++ b/ps-thin/src/petuum_ps/server/server.hpp
@@ -40,17 +40,14 @@ private:
            boost::unordered_map<int32_t, std::vector<ServerRowRequest>>>
       clock_bg_row_requests_;
   // Keep track of the latest oplog version received from each bg thread
-  std::map<int32_t, uint32_t> bg_version_map_;
+  std::map<int32_t, int32_t> bg_version_map_;
   int32_t server_id_;
   size_t accum_oplog_count_;
   HighResolutionTimer from_start_timer_;
   bool is_replica_;
 
-  ServerTable *GetServerTable(int32_t table_id) {
-    auto table_iter = tables_.find(table_id);
-    CHECK(table_iter != tables_.end()) << "Not found table_id = " << table_id;
-    return &(table_iter->second);
-  }
+    ServerTable *GetServerTable(int32_t table_id);
+    void TakeSnapShot(int32_t current_clock);
 
 public:
   Server();

--- a/ps-thin/src/petuum_ps/server/server.hpp
+++ b/ps-thin/src/petuum_ps/server/server.hpp
@@ -65,5 +65,4 @@ public:
   int32_t GetBgVersion(int32_t bg_thread_id);
   double GetElapsedTime();
 };
-
 }

--- a/ps-thin/src/petuum_ps/server/server.hpp
+++ b/ps-thin/src/petuum_ps/server/server.hpp
@@ -27,69 +27,43 @@ public:
 
 // 1. Manage the table storage on server;
 // 2. Manage the pending reads;
-// 3. Manage the vector clock for clients
-// 4. (TODO): manage OpLogs that need acknowledgements
+// 3. Manage the vector clock for clients;
 
 class Server {
+private:
+  VectorClock bg_clock_;
+  boost::unordered_map<int32_t, ServerTable> tables_;
+  // mapping <clock, table id> to an array of row requests
+  // Keeping track of all pending row requests. These are indexed first by the
+  // clock requested by each row and secondly by the table id.
+  std::map<int32_t,
+           boost::unordered_map<int32_t, std::vector<ServerRowRequest>>>
+      clock_bg_row_requests_;
+  // Keep track of the latest oplog version received from each bg thread
+  std::map<int32_t, uint32_t> bg_version_map_;
+  int32_t server_id_;
+  size_t accum_oplog_count_;
+  HighResolutionTimer from_start_timer_;
+  bool is_replica_;
+
 public:
   Server();
   ~Server();
-
   void Init(int32_t server_id, const std::vector<int32_t> &bg_ids,
             bool is_replica = false);
-
   void CreateTable(int32_t table_id, TableInfo &table_info);
-
   ServerRow *FindCreateRow(int32_t table_id, int32_t row_id);
-
   bool ClockUntil(int32_t bg_id, int32_t clock);
-
   void AddRowRequest(int32_t bg_id, int32_t table_id, int32_t row_id,
                      int32_t clock);
-
   void GetFulfilledRowRequests(std::vector<ServerRowRequest> *requests);
-
   void ApplyOpLogUpdateVersion(const void *oplog, size_t oplog_size,
                                int32_t bg_thread_id, uint32_t version,
                                int32_t *observed_delay);
-
   // Accessors
   int32_t GetMinClock();
   int32_t GetBgVersion(int32_t bg_thread_id);
   double GetElapsedTime();
+};
 
-private:
-  double GetUpdateScalingFactor(int32_t row_update_version) {
-    if (false == GlobalContext::is_asynchronous_mode()) {
-      return 1.0;
-    }
-    int row_update_delay = async_version_ - row_update_version;
-    int corrected = std::max(1, row_update_delay);
-    return 1.0 / corrected;
-  }
-
-  void updateOplogDelay(int32_t *observed_delay, int32_t row_update_version) {
-    int row_update_delay = async_version_ - row_update_version;
-    *observed_delay = std::max(row_update_delay, *observed_delay);
-  }
-
-  VectorClock bg_clock_;
-  int32_t async_version_;
-  boost::unordered_map<int32_t, ServerTable> tables_;
-  // mapping <clock, table id> to an array of row requests
-  std::map<int32_t,
-           boost::unordered_map<int32_t, std::vector<ServerRowRequest>>>
-      clock_bg_row_requests_;
-  // latest oplog version that I have received from a bg thread
-  std::map<int32_t, uint32_t> bg_version_map_;
-  // Assume a single row does not exceed this size!
-  static const size_t kPushRowMsgSizeInit = 4 * k1_Mi;
-  size_t push_row_msg_data_size_;
-  int32_t server_id_;
-  size_t accum_oplog_count_;
-  bool is_replica_;
-  HighResolutionTimer from_start_timer_;
-
-}; // end class -- Server
-
-} // namespace petuum
+}

--- a/ps-thin/src/petuum_ps/server/server.hpp
+++ b/ps-thin/src/petuum_ps/server/server.hpp
@@ -46,8 +46,8 @@ private:
   HighResolutionTimer from_start_timer_;
   bool is_replica_;
 
-    ServerTable *GetServerTable(int32_t table_id);
-    void TakeSnapShot(int32_t current_clock);
+  ServerTable *GetServerTable(int32_t table_id);
+  void TakeSnapShot(int32_t current_clock);
 
 public:
   Server();

--- a/ps-thin/src/petuum_ps/server/server_row.hpp
+++ b/ps-thin/src/petuum_ps/server/server_row.hpp
@@ -12,19 +12,20 @@ namespace petuum {
 // Allow move sematic for it to be stored in STL containers.
 class ServerRow : boost::noncopyable {
 public:
-  ServerRow() : dirty_(false) {}
+  ServerRow() : dirty_(false), row_version_(0) {}
   ServerRow(AbstractRow *row_data)
-      : row_data_(row_data), num_clients_subscribed_(0), dirty_(false) {}
+      : row_data_(row_data), num_clients_subscribed_(0), dirty_(false),
+        row_version_(0) {}
 
   ~ServerRow() {
-    if (row_data_ != 0)
+    if (row_data_ != nullptr)
       delete row_data_;
   }
 
   ServerRow(ServerRow &&other)
       : row_data_(other.row_data_),
         num_clients_subscribed_(other.num_clients_subscribed_),
-        dirty_(other.dirty_) {
+        dirty_(other.dirty_), row_version_(other.row_version_) {
     other.row_data_ = 0;
   }
 
@@ -77,6 +78,10 @@ public:
       --num_clients_subscribed_;
   }
 
+  void IncrementVersion() { row_version_++; }
+
+  unsigned long GetRowVersion() { return row_version_; }
+
   bool IsDirty() { return dirty_; }
 
   void ResetDirty() { dirty_ = false; }
@@ -91,10 +96,9 @@ private:
   CallBackSubs callback_subs_;
   AbstractRow *row_data_;
   size_t num_clients_subscribed_;
-
   bool dirty_;
-
   double importance_;
+  unsigned long row_version_;
 };
 
 } // end namespace -- petuum

--- a/ps-thin/src/petuum_ps/server/server_table.hpp
+++ b/ps-thin/src/petuum_ps/server/server_table.hpp
@@ -119,6 +119,7 @@ public:
     }
     ApplyRowBatchInc_(column_ids, updates, num_updates, &(row_iter->second),
                       scale);
+    row_iter->second.IncrementVersion();
     return true;
   }
 

--- a/ps-thin/src/petuum_ps/server/server_table.hpp
+++ b/ps-thin/src/petuum_ps/server/server_table.hpp
@@ -52,7 +52,6 @@ public:
           new SparseRowOpLog(InitUpdateFunc(), CheckZeroUpdateFunc(),
                              sample_row_->get_update_size());
     }
-
   }
 
   /**
@@ -94,11 +93,11 @@ public:
   }
 
   ServerRow *FindCreateRow(int32_t row_id) {
-      ServerRow *row = FindRow(row_id);
-      if(nullptr == row) {
-          return CreateRow(row_id);
-      }
-      return row;
+    ServerRow *row = FindRow(row_id);
+    if (nullptr == row) {
+      return CreateRow(row_id);
+    }
+    return row;
   }
 
   /**

--- a/ps-thin/src/petuum_ps/server/server_table.hpp
+++ b/ps-thin/src/petuum_ps/server/server_table.hpp
@@ -53,7 +53,7 @@ public:
                              sample_row_->get_update_size());
     }
 
-  } // end function -- Constructor
+  }
 
   /**
    * Destructor.
@@ -91,6 +91,14 @@ public:
     if (row_iter == storage_.end())
       return 0;
     return &(row_iter->second);
+  }
+
+  ServerRow *FindCreateRow(int32_t row_id) {
+      ServerRow *row = FindRow(row_id);
+      if(nullptr == row) {
+          return CreateRow(row_id);
+      }
+      return row;
   }
 
   /**

--- a/ps-thin/src/petuum_ps/server/server_thread.cpp
+++ b/ps-thin/src/petuum_ps/server/server_thread.cpp
@@ -213,7 +213,6 @@ void ServerThread::HandleRowRequest(int32_t sender_id,
 
   ReplyRowRequest(sender_id, server_row, table_id, row_id, return_clock,
                   bg_version, server_row->GetRowVersion());
-
 }
 
 void ServerThread::ReplyRowRequest(
@@ -229,7 +228,7 @@ void ServerThread::ReplyRowRequest(
   server_row_request_reply_msg.get_clock() = client_clock;
   server_row_request_reply_msg.get_version() = bg_version;
   server_row_request_reply_msg.get_global_model_version() =
-          (int32_t) server_row_global_version;
+      (int32_t)server_row_global_version;
   // TODO(raajay) change the serialization to use unsigned long and remove cast
 
   row_size = server_row->Serialize(server_row_request_reply_msg.get_row_data());

--- a/ps-thin/src/petuum_ps/server/server_thread.cpp
+++ b/ps-thin/src/petuum_ps/server/server_thread.cpp
@@ -214,12 +214,12 @@ void ServerThread::HandleRowRequest(int32_t sender_id,
   ReplyRowRequest(sender_id, server_row, table_id, row_id, return_clock,
                   bg_version, server_row->GetRowVersion());
 
-} // end function -- handle row request
+}
 
 void ServerThread::ReplyRowRequest(
     int32_t bg_id, ServerRow *server_row, int32_t table_id, int32_t row_id,
     int32_t client_clock, // earlier we used to return server clock
-    uint32_t bg_version, int32_t server_row_global_version) {
+    uint32_t bg_version, unsigned long server_row_global_version) {
 
   size_t row_size = server_row->SerializedSize();
 
@@ -229,7 +229,8 @@ void ServerThread::ReplyRowRequest(
   server_row_request_reply_msg.get_clock() = client_clock;
   server_row_request_reply_msg.get_version() = bg_version;
   server_row_request_reply_msg.get_global_model_version() =
-      server_row_global_version;
+          (int32_t) server_row_global_version;
+  // TODO(raajay) change the serialization to use unsigned long and remove cast
 
   row_size = server_row->Serialize(server_row_request_reply_msg.get_row_data());
   server_row_request_reply_msg.get_row_size() = row_size;
@@ -260,9 +261,9 @@ void ServerThread::HandleOpLogMsg(int32_t sender_id,
                                       client_send_oplog_msg.get_avai_size(),
                                       sender_id, version, &observed_delay);
   STATS_SERVER_ACCUM_APPLY_OPLOG_END();
-  // STATS_MLFABRIC_SERVER_RECORD_DELAY(observed_delay);
 
   // TODO add delay to the statistics
+  // STATS_MLFABRIC_SERVER_RECORD_DELAY(observed_delay);
 
   bool clock_changed = false;
   if (is_clock) {

--- a/ps-thin/src/petuum_ps/server/server_thread.hpp
+++ b/ps-thin/src/petuum_ps/server/server_thread.hpp
@@ -53,7 +53,7 @@ protected:
 
   void ReplyRowRequest(int32_t bg_id, ServerRow *server_row, int32_t table_id,
                        int32_t row_id, int32_t server_clock, uint32_t version,
-                       int32_t global_model_version);
+                       unsigned long global_model_version);
 
   void HandleOpLogMsg(int32_t sender_id,
                       ClientSendOpLogMsg &client_send_oplog_msg);


### PR DESCRIPTION
* Do not use a single variables representing the model version for all the data stored in the server.
Keep a version number for each row. 

* Remove code for delay based scaling.